### PR TITLE
add transistor sizing paper

### DIFF
--- a/publications/layoutVer.bib
+++ b/publications/layoutVer.bib
@@ -285,3 +285,12 @@
   doi     = {10.1109/TCSI.2022.3147587},
   url     = {https://ieeexplore.ieee.org/document/9704874}
 }
+
+@article{li2021circuitsizing,
+  author    = {Li, Yaguang and Lin, Yishuang and Madhusudan, Meghna and Sharma, Arvind and Sapatnekar, Sachin and Harjani, Ramesh and Hu, Jiang},
+  title     = {A circuit attention network-based actor-critic learning approach to robust analog transistor sizing},
+  year      = {2021},
+  _venue    = {MLCAD},
+  url       = {https://ieeexplore.ieee.org/document/9531156},
+  topic     = {Gate Sizing}
+}


### PR DESCRIPTION
add paper "A circuit attention network-based actor-critic learning approach to robust analog transistor sizing"